### PR TITLE
reenable CAF maps

### DIFF
--- a/layers.json
+++ b/layers.json
@@ -724,7 +724,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -738,7 +738,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -752,7 +752,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -1004,7 +1004,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -1018,7 +1018,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -1032,7 +1032,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -1186,7 +1186,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -1200,7 +1200,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -1410,7 +1410,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1424,7 +1424,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1438,7 +1438,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1452,7 +1452,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1466,7 +1466,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1480,7 +1480,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1662,7 +1662,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1676,7 +1676,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1690,7 +1690,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -1704,7 +1704,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "unknown"
   },
   {
@@ -2516,7 +2516,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -2530,7 +2530,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": true,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   },
   {
@@ -2544,7 +2544,7 @@
     "night": false,
     "RAA_Lanes": false,
     "Invasion_Random": false,
-    "bugged": true,
+    "bugged": false,
     "map_size": "large"
   }
 ]


### PR DESCRIPTION
turning on CAF maps again since they seem to be fixed.
from https://discordapp.com/channels/101469020510773248/213807309460078602/652284366382170123
(Dec 5 2019):
> with that update, CAF layers should be playable again. Some known layer issues:
CAF_Manic_RAAS_v4 - No cap points for both teams, so avoid that one
CAF_Manic_Invasion_v2 - US have broken ammo crates at main so they are unusable
Skirmish layers (2) on Manic - Commander is enabled, probably not ideal for skirmish layers